### PR TITLE
Adds byte indicator before the "propertyName"

### DIFF
--- a/toggle_button.py
+++ b/toggle_button.py
@@ -128,13 +128,13 @@ class ToggleButton(QtWidgets.QWidget):
         widget.setStyleSheet(css)
 
     def _doToggleAnim(self, xStart, xEnd, startColor, endColor):
-        self.anim = QtCore.QPropertyAnimation(self.toggle_switch, 'pos')
+        self.anim = QtCore.QPropertyAnimation(self.toggle_switch, b'pos')
         self.anim.setDuration(100)
         self.anim.setStartValue(QtCore.QPoint(xStart, self.padding))
         self.anim.setEndValue(QtCore.QPoint(xEnd, self.padding))
         self.anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
 
-        self.animbg = QtCore.QPropertyAnimation(self.toggle_bg, 'color')
+        self.animbg = QtCore.QPropertyAnimation(self.toggle_bg, b'color')
         self.animbg.setDuration(200)
         self.animbg.setStartValue(startColor)
         self.animbg.setEndValue(endColor)


### PR DESCRIPTION
Since PySide2 Version 5.11.0 you get a error if you pass the *propertyName* as default string.

To solve this issue, simply add a *b* in front of your string to turn it into bytes.
This fix is backward compatible so it still works with Maya's PySide2 Version (2.0.0~alpha0).